### PR TITLE
Add Ruby script for Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,14 @@ QuickLook Plugin for [CommonMark](https://commonmark.org) documents by using [cm
 
 ## Installation
 
-To install qlcmark-gfm, please copy or move `qlcmark-gfm.qlgenerator` to `~/Library/QuickLook` and execute following command in Terminal.app.
-    
+Via Homebrew
+
+    $ # installed to ~/Library/QuickLook
+    $ brew cask install https://raw.githubusercontent.com/rokudogobu/qlcmark-gfm/master/qlcmark-gfm.rb
+    $ xattr -r -d com.apple.quarantine ~/Library/QuickLook/qlcmark-gfm.qlgenerator
+
+Optionally, clear QuickLook client's generator cache
+
     $ qlmanage -r
 
 If you want to build from source, please make sure `cmake` is installed to your mac, and then follow the steps below.

--- a/qlcmark-gfm.rb
+++ b/qlcmark-gfm.rb
@@ -1,0 +1,11 @@
+cask 'qlcmark-gfm' do
+  version '1.3.1'
+  sha256 '6a786ce0199220a0f09942fb9388c8676ba28cd9e6be8e619812fb4377d83c53'
+
+  url "https://github.com/rokudogobu/qlcmark-gfm/releases/download/v#{version}/qlcmark-gfm.qlgenerator.zip"
+  appcast 'https://github.com/rokudogobu/qlcmark-gfm/releases.atom'
+  name 'qlcmark-gfm'
+  homepage 'https://github.com/rokudogobu/qlcmark-gfm'
+
+  qlplugin 'qlcmark-gfm.qlgenerator'
+end


### PR DESCRIPTION
Install via Homebrew: `brew cask install https://raw.githubusercontent.com/rokudogobu/qlcmark-gfm/master/qlcmark-gfm.rb`. This file doesn't exist on your repo yet, so you should test it via `brew cask install https://raw.githubusercontent.com/xiruizhao/qlcmark-gfm/master/qlcmark-gfm.rb`